### PR TITLE
feat(prose): underline links by default

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -110,6 +110,9 @@ export default defineAppConfig({
       },
     },
     prose: {
+      a: {
+        base: 'rounded-none border-current hover:text-muted hover:border-current [&>code]:border-current hover:[&>code]:text-muted hover:[&>code]:border-current',
+      },
       codePreview: {
         slots: {
           preview: 'flex-col *:w-full [&_a]:w-fit',


### PR DESCRIPTION
Prose links now show their underline all the time instead of only on hover, using `border-current` so it always matches the text color. Hover dims both the text and the underline to `text-muted`, and `rounded-none` removes the small curl the default `rounded-xs` gave the underline ends.