### PR TITLE
perf: render static prose tags as native elements with baked-in classes

### DIFF
--- a/app/assets/css/theme.css
+++ b/app/assets/css/theme.css
@@ -165,3 +165,20 @@ html.dark .shiki span {
 .mermaid {
   @apply rounded overflow-hidden border border-muted bg-white dark:bg-muted;
 }
+
+/*
+ * Heading anchor icon (`lucide:hash`) for headings rendered as plain elements by the `elements`
+ * comark plugin (`server/utils/comark-elements.ts`). Replaces `<UIcon name="lucide:hash">`,
+ * whose CSS `@nuxt/icon` only emits for rendered components. Same mask technique as iconify.
+ */
+.prose-anchor-icon {
+  --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 9h16M4 15h16M10 3L8 21M16 3l-2 21'/%3E%3C/svg%3E");
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask-image: var(--svg);
+  mask-image: var(--svg);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+}

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -122,7 +122,7 @@ if (content.value.mode === 'prod') {
       <MarkdownDocument
         v-if="tree"
         :value="tree"
-        :components="{ Mermaid, CodeExplorer, Browser }"
+        :components="{ ...proseElements, Mermaid, CodeExplorer, Browser }"
       />
 
       <UContentSurround

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -8,6 +8,7 @@ import LandingCta from '../components/landing/LandingCta.vue'
 import LandingHeroDemo from '../components/landing/LandingHeroDemo.vue'
 
 const landingComponents = {
+  ...proseElements,
   LandingStack,
   LandingTabs,
   LandingFeatures,

--- a/app/utils/prose-elements.ts
+++ b/app/utils/prose-elements.ts
@@ -1,0 +1,45 @@
+import { defineAsyncComponent, hydrateOnVisible } from 'vue'
+
+/**
+ * `ProseImg` keeps its component (zoom dialog), but hydrates lazily: the chunk only downloads
+ * and hydrates once an image scrolls into the viewport.
+ */
+const LazyProseImg = defineAsyncComponent({
+  loader: () => import('@nuxt/ui/runtime/components/prose/Img.vue'),
+  hydrate: hydrateOnVisible(),
+})
+
+/**
+ * Component map for `<MarkdownDocument :components>` covering every tag the `elements` comark
+ * plugin (`server/utils/comark-elements.ts`) rewrites to final HTML with baked-in classes.
+ *
+ * Mapping a tag to its own name short-circuits the renderer's `Prose*` lookup, so it emits a
+ * plain element (`h('p')`) instead of mounting the global Nuxt UI component — removing per-node
+ * component instances from SSR, hydration, and client-side navigation. Children still render
+ * normally, so links and inline components inside these elements stay interactive.
+ */
+export const proseElements = {
+  p: 'p',
+  em: 'em',
+  strong: 'strong',
+  hr: 'hr',
+  ul: 'ul',
+  ol: 'ol',
+  li: 'li',
+  blockquote: 'blockquote',
+  code: 'code',
+  table: 'table',
+  thead: 'thead',
+  tbody: 'tbody',
+  tr: 'tr',
+  th: 'th',
+  td: 'td',
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  // Heading anchor links emitted by the plugin: rendered as plain `<a>` (a bare `a` tag would
+  // resolve to the global `ProseA` and pick up content-link styling).
+  'prose-anchor': 'a',
+  img: LazyProseImg,
+}

--- a/modules/css.ts
+++ b/modules/css.ts
@@ -23,6 +23,9 @@ export default defineNuxtModule({
 
     const sources = [
       resolver.resolve('../app'),
+      // The `elements` comark plugin bakes prose classes into parsed trees at runtime; scanning
+      // `server/` keeps those literals covered even if they drift from the Nuxt UI prose theme.
+      resolver.resolve('../server'),
       nuxt.options.srcDir,
       resolve(nuxt.options.rootDir, 'content'),
     ].map((dir) => `${dir}/**/*`.replace(/\\/g, '/'))

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "pathe": "^2.0.3",
     "rangi": "^2.2.0",
     "satori": "^0.29.1",
+    "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.3.3",
     "ufo": "^1.6.4",
     "unstorage": "^1.17.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       satori:
         specifier: ^0.29.1
         version: 0.29.1
+      tailwind-variants:
+        specifier: ^3.2.2
+        version: 3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -17,7 +17,7 @@ function cacheAvailable(): boolean {
  * Bump when content parser/plugin configuration, relevant parser dependencies, or cached derived
  * data changes. Keeping this explicit lets unrelated deployments reuse immutable content artifacts.
  */
-export const CONTENT_PARSER_VERSION = 'v2'
+export const CONTENT_PARSER_VERSION = 'v3'
 
 /** Per-parser-version, per-content-SHA driver backing comark's manifest and parsed bodies. */
 export function cacheDriver(sha: string): Driver {

--- a/server/utils/comark-elements.ts
+++ b/server/utils/comark-elements.ts
@@ -1,0 +1,281 @@
+import { defineComarkPlugin } from 'comark'
+import type { ElementNode, Node } from 'comark'
+import { createTV } from 'tailwind-variants'
+
+/**
+ * `elements` comark plugin.
+ *
+ * Rewrites static prose tags into final HTML elements at parse time, baking their Tailwind
+ * classes into the tree. Paired with the `proseElements` map (`app/utils/prose-elements.ts`)
+ * passed to `<MarkdownDocument :components>`, the Vue renderer then emits plain elements
+ * instead of mounting a Nuxt UI `Prose*` component per node — removing thousands of component
+ * instances from SSR, hydration, and client-side navigation on long docs pages. Children are
+ * rendered normally, so links and inline components inside these elements stay interactive.
+ *
+ * Class strings mirror the compiled Nuxt UI v4 prose theme (`#build/ui/prose/*` — not
+ * importable from nitro, where `#build` is forbidden) and are merged with the
+ * `appConfig.ui.prose.*` overrides through `tailwind-variants`, exactly like the `Prose*`
+ * components do (`tv({ extend: theme, ...appConfig.ui?.prose?.[tag] })`). Keep the literals in
+ * sync when upgrading `@nuxt/ui`. Tailwind generates these classes because the Nuxt UI prose
+ * theme stays registered (`ui: { prose: true }`) and `modules/css.ts` adds `server/` as a
+ * Tailwind source.
+ *
+ * Interactive prose tags (`a`, `pre`, `img`, callouts, tabs, ...) are left untouched and keep
+ * resolving to their components.
+ */
+
+/** Mirrors `#build/ui/prose/*` (Nuxt UI 4.11, `theme.transitions: true`). */
+const theme = {
+  p: { base: 'my-5 leading-7 text-pretty' },
+  em: { base: '' },
+  strong: { base: '' },
+  hr: { base: 'border-t border-default my-12' },
+  ul: { base: 'list-disc ps-6 my-5 marker:text-(--ui-border-accented)' },
+  ol: { base: 'list-decimal ps-6 my-5 marker:text-muted' },
+  li: { base: 'my-1.5 ps-1.5 leading-7 [&>ul]:my-0' },
+  blockquote: { base: 'border-s-4 border-accented ps-4 italic' },
+  code: {
+    base: 'px-1.5 py-0.5 text-sm font-mono font-medium rounded-md inline-block',
+    variants: {
+      color: {
+        primary: 'border border-primary/25 bg-primary/10 text-primary',
+        secondary: 'border border-secondary/25 bg-secondary/10 text-secondary',
+        success: 'border border-success/25 bg-success/10 text-success',
+        info: 'border border-info/25 bg-info/10 text-info',
+        warning: 'border border-warning/25 bg-warning/10 text-warning',
+        error: 'border border-error/25 bg-error/10 text-error',
+        neutral: 'border border-muted text-highlighted bg-muted',
+      },
+    },
+    defaultVariants: { color: 'neutral' },
+  },
+  table: {
+    slots: {
+      root: 'relative my-5 overflow-x-auto rounded-md outline-primary/25 focus-visible:outline-3',
+      base: 'w-full border-separate border-spacing-0 rounded-md',
+    },
+  },
+  thead: { base: 'bg-muted' },
+  tbody: { base: '' },
+  tr: { base: '[&:first-child>th:first-child]:rounded-ss-md [&:first-child>th:last-child]:rounded-se-md [&:last-child>td:first-child]:rounded-es-md [&:last-child>td:last-child]:rounded-ee-md' },
+  th: {
+    base: 'py-3 px-4 font-semibold text-sm border-e border-b first:border-s border-t border-muted',
+    variants: {
+      align: { left: 'text-start', center: 'text-center', right: 'text-end' },
+    },
+    defaultVariants: { align: 'left' },
+  },
+  td: {
+    base: 'py-3 px-4 text-sm align-top border-e border-b first:border-s border-muted [&_code]:text-xs/5 [&_p]:my-0 [&_p]:leading-6 [&_ul]:my-0 [&_ol]:my-0 [&_ul]:ps-4.5 [&_ol]:ps-4.5 [&_li]:leading-6 [&_li]:my-0.5',
+    variants: {
+      align: { left: 'text-start', center: 'text-center', right: 'text-end' },
+    },
+    defaultVariants: { align: 'left' },
+  },
+  h1: {
+    slots: {
+      base: 'text-4xl text-highlighted font-bold mb-8 scroll-mt-[calc(45px+var(--ui-header-height))] lg:scroll-mt-(--ui-header-height)',
+      link: 'inline-flex items-center gap-2',
+    },
+  },
+  h2: {
+    slots: {
+      base: [
+        'relative text-2xl text-highlighted font-bold mt-12 mb-6 scroll-mt-[calc(48px+45px+var(--ui-header-height))] lg:scroll-mt-[calc(48px+var(--ui-header-height))] [&>a]:rounded-sm [&>a]:outline-primary/25 [&>a]:focus-visible:outline-3 [&>a>code]:border-dashed hover:[&>a>code]:border-primary hover:[&>a>code]:text-primary [&>a>code]:text-xl/7 [&>a>code]:font-bold',
+        '[&>a>code]:transition-colors',
+      ],
+      leading: [
+        'absolute -ms-8 top-1 opacity-0 group-hover:opacity-100 group-focus:opacity-100 p-1 bg-elevated group-hover:text-primary group-focus:text-primary rounded-md hidden lg:flex text-muted',
+        'transition',
+      ],
+      leadingIcon: 'size-4 shrink-0',
+      link: 'group lg:after:absolute lg:after:inset-y-0 lg:after:-inset-s-2 lg:after:w-2',
+    },
+  },
+  h3: {
+    slots: {
+      base: [
+        'relative text-xl text-highlighted font-bold mt-8 mb-3 scroll-mt-[calc(32px+45px+var(--ui-header-height))] lg:scroll-mt-[calc(32px+var(--ui-header-height))] [&>a]:rounded-sm [&>a]:outline-primary/25 [&>a]:focus-visible:outline-3 [&>a>code]:border-dashed hover:[&>a>code]:border-primary hover:[&>a>code]:text-primary [&>a>code]:text-lg/6 [&>a>code]:font-bold',
+        '[&>a>code]:transition-colors',
+      ],
+      leading: [
+        'absolute -ms-8 top-0.5 opacity-0 group-hover:opacity-100 group-focus:opacity-100 p-1 bg-elevated group-hover:text-primary group-focus:text-primary rounded-md hidden lg:flex text-muted',
+        'transition',
+      ],
+      leadingIcon: 'size-4 shrink-0',
+      link: 'group lg:after:absolute lg:after:inset-y-0 lg:after:-inset-s-2 lg:after:w-2',
+    },
+  },
+  h4: {
+    slots: {
+      base: 'text-lg text-highlighted font-bold mt-6 mb-2 scroll-mt-[calc(24px+45px+var(--ui-header-height))] lg:scroll-mt-[calc(24px+var(--ui-header-height))] [&>a]:rounded-sm [&>a]:outline-primary/25 [&>a]:focus-visible:outline-3',
+      link: '',
+    },
+  },
+} as const
+
+const SIMPLE_TAGS = ['p', 'em', 'strong', 'hr', 'ul', 'ol', 'li', 'blockquote', 'thead', 'tbody', 'tr'] as const
+const HEADING_TAGS = ['h1', 'h2', 'h3', 'h4'] as const
+
+type SimpleTag = (typeof SIMPLE_TAGS)[number]
+type HeadingTag = (typeof HEADING_TAGS)[number]
+type SlotFn = (props?: Record<string, unknown>) => string
+
+export interface ElementsOptions {
+  /**
+   * Which heading levels get an anchor link wrapping their content, like `ProseH1`-`ProseH4`.
+   * Defaults to `runtimeConfig.public.mdc.headings.anchorLinks`.
+   */
+  anchorLinks?: boolean | Partial<Record<HeadingTag, boolean>>
+}
+
+interface Ui {
+  simple: Record<SimpleTag, SlotFn>
+  code: SlotFn
+  cell: Record<'th' | 'td', SlotFn>
+  table: { root: SlotFn, base: string }
+  headings: Record<HeadingTag, { base: SlotFn, link: string, leading?: string, icon?: string, anchor: boolean }>
+}
+
+export const elements = defineComarkPlugin<ElementsOptions>((options = {}) => {
+  // Built lazily on first parse: `useAppConfig()`/`useRuntimeConfig()` need the nitro runtime.
+  let ui: Ui | undefined
+
+  return {
+    name: 'elements',
+    post(state) {
+      ui ??= buildUi(options)
+      const nodes = state.tree.nodes
+      for (let i = 0; i < nodes.length; i++) {
+        nodes[i] = walk(nodes[i]!, ui)
+      }
+    },
+  }
+})
+
+function buildUi(options: ElementsOptions): Ui {
+  const appConfig = useAppConfig() as {
+    ui?: { tv?: Parameters<typeof createTV>[0], prose?: Record<string, object> }
+  }
+  // Same construction as Nuxt UI's own `tv` util: `createTV(appConfig.ui?.tv)` +
+  // `tv({ extend: theme, ...appConfig.ui?.prose?.[tag] })` per component.
+  const tv = createTV(appConfig.ui?.tv as never)
+  const prose = appConfig.ui?.prose ?? {}
+  const component = (tag: keyof typeof theme) =>
+    tv({ extend: theme[tag], ...(prose[tag] ?? {}) } as never) as unknown
+
+  const { mdc } = (useRuntimeConfig().public ?? {}) as {
+    mdc?: { headings?: { anchorLinks?: boolean | Partial<Record<HeadingTag, boolean>> } }
+  }
+  const anchorLinks = options.anchorLinks ?? mdc?.headings?.anchorLinks
+  const anchorFor = (tag: HeadingTag) =>
+    typeof anchorLinks === 'boolean' ? anchorLinks : anchorLinks?.[tag] ?? false
+
+  const simple = Object.fromEntries(
+    SIMPLE_TAGS.map((tag) => [tag, component(tag) as SlotFn])
+  ) as Record<SimpleTag, SlotFn>
+
+  const tableSlots = (component('table') as () => Record<'root' | 'base', SlotFn>)()
+
+  const headings = {} as Ui['headings']
+  for (const tag of HEADING_TAGS) {
+    const slots = (component(tag) as () => Record<string, SlotFn | undefined>)()
+    headings[tag] = {
+      base: slots.base!,
+      link: slots.link?.() ?? '',
+      leading: slots.leading?.(),
+      icon: slots.leadingIcon ? [slots.leadingIcon(), 'prose-anchor-icon'].filter(Boolean).join(' ') : undefined,
+      anchor: anchorFor(tag),
+    }
+  }
+
+  return {
+    simple,
+    code: component('code') as SlotFn,
+    cell: { th: component('th') as SlotFn, td: component('td') as SlotFn },
+    table: { root: tableSlots.root, base: tableSlots.base() },
+    headings,
+  }
+}
+
+function walk(node: Node, ui: Ui): Node {
+  if (!Array.isArray(node)) return node
+  const tag = node[0]
+  // Skip comments and `<pre>` subtrees: rangi bakes its own highlight markup there and the
+  // renderer already renders `<pre>` children as native elements.
+  if (typeof tag !== 'string' || tag === 'pre') return node
+  // Bottom-up: children first, so wrappers (table, heading anchors) never re-process themselves.
+  for (let i = 2; i < node.length; i++) {
+    node[i] = walk(node[i] as Node, ui)
+  }
+  return transform(node as ElementNode, ui) ?? node
+}
+
+/** Mutates `node` in place; returns a replacement node only when the tag needs a wrapper. */
+function transform(node: ElementNode, ui: Ui): Node | undefined {
+  const tag = node[0]
+  const attrs = (node[1] ??= {})
+
+  if (isIn(SIMPLE_TAGS, tag)) {
+    setClass(attrs, ui.simple[tag]({ class: attrs.class }))
+    return
+  }
+
+  if (tag === 'code') {
+    const color = attrs.color
+    delete attrs.color
+    delete attrs.lang
+    // ProseCode joins comma-separated classes (markdown attribute syntax) with spaces.
+    const authorClass = typeof attrs.class === 'string' ? attrs.class.split(',').join(' ') : attrs.class
+    setClass(attrs, ui.code({ color, class: authorClass }))
+    return
+  }
+
+  if (tag === 'th' || tag === 'td') {
+    const align = attrs.align
+    delete attrs.align
+    setClass(attrs, ui.cell[tag]({ align, class: attrs.class }))
+    return
+  }
+
+  if (tag === 'table') {
+    // ProseTable wraps the table in a scroll container div.
+    const rootClass = ui.table.root({ class: attrs.class })
+    setClass(attrs, ui.table.base)
+    return ['div', { class: rootClass }, node]
+  }
+
+  if (isIn(HEADING_TAGS, tag)) {
+    const heading = ui.headings[tag]
+    const anchor = parseBool(attrs.anchor)
+    delete attrs.anchor
+    setClass(attrs, heading.base({ class: attrs.class }))
+    const id = attrs.id
+    if (!id || !(anchor ?? heading.anchor)) return
+    // Wrap the heading's children in the anchor link, like ProseH1-ProseH4 do. The tag must NOT
+    // be `a`: the renderer would resolve it to the global `ProseA` (content-link styling).
+    // `proseElements` maps `prose-anchor` back to a plain `<a>`.
+    const link: ElementNode = ['prose-anchor', { href: `#${id}` }, ...(node.splice(2) as Node[])]
+    setClass(link[1], heading.link)
+    if (heading.leading) {
+      link.splice(2, 0, ['span', { class: heading.leading }, ['span', { 'class': heading.icon, 'aria-hidden': 'true' }]])
+    }
+    node.push(link)
+    return
+  }
+}
+
+function setClass(attrs: ElementNode[1], value: string | undefined) {
+  if (value) attrs.class = value
+  else delete attrs.class
+}
+
+function parseBool(value: unknown): boolean | undefined {
+  if (value === true || value === '' || value === 'true') return true
+  if (value === false || value === 'false') return false
+  return undefined
+}
+
+function isIn<const T extends readonly string[]>(list: T, tag: string): tag is T[number] {
+  return (list as readonly string[]).includes(tag)
+}

--- a/server/utils/content.ts
+++ b/server/utils/content.ts
@@ -9,6 +9,7 @@ import mermaid from 'comark/plugins/mermaid'
 import yaml from 'comark-content/plugins/yaml'
 import tracingOtel from 'comark-content/plugins/tracing/otel'
 import { contentTracer } from './tracer.ts'
+import { elements } from './comark-elements.ts'
 import { geistTheme } from '../../utils/geist-theme.ts'
 
 // Rebuilt only when the head advances (see `getProdContent`). Holds the *promise*, not the instance: the
@@ -25,6 +26,8 @@ const comarkPlugins = [
     blockedTags: ['script', 'iframe', 'embed', 'form', 'base', 'meta', 'link', 'style'],
     allowDataImages: false,
   }),
+  // Last: bakes prose classes into static tags (after `toc` assigned heading ids).
+  elements(),
 ]
 
 // Bound to THIS instance so a preview content instance serves its own version's sections, not production's.

--- a/test/comark-elements.test.ts
+++ b/test/comark-elements.test.ts
@@ -1,0 +1,151 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { parseMarkdown } from 'comark'
+import toc from 'comark/plugins/toc'
+import type { ElementNode, Node } from 'comark'
+import { elements } from '../server/utils/comark-elements'
+
+// The plugin reads `useAppConfig()` / `useRuntimeConfig().public` lazily on first parse (nitro
+// globals). Vitest isolates files, so overriding the setup.ts stubs here leaks nowhere.
+const globals = globalThis as Record<string, unknown>
+
+beforeAll(() => {
+  globals.useAppConfig = () => ({
+    ui: {
+      prose: {
+        p: { base: 'text-accented' },
+        code: { base: '[font-variant-ligatures:none]' },
+        h2: { slots: { base: 'font-medium' } },
+        td: { base: 'bg-white dark:bg-muted/80' },
+      },
+    },
+  })
+  globals.useRuntimeConfig = () => ({
+    public: { mdc: { headings: { anchorLinks: { h2: true, h3: true, h4: true } } } },
+  })
+})
+
+async function parse(markdown: string): Promise<Node[]> {
+  const doc = await parseMarkdown(markdown, { plugins: [toc({ depth: 3 }), elements()] })
+  return doc.nodes
+}
+
+function el(node: Node | undefined): ElementNode {
+  expect(Array.isArray(node)).toBe(true)
+  return node as ElementNode
+}
+
+describe('elements comark plugin', () => {
+  it('bakes theme classes into simple tags, merged with app.config.ui.prose overrides', async () => {
+    const [p] = await parse('Hello world')
+    expect(el(p)[0]).toBe('p')
+    // theme base + app.config override, tailwind-merged
+    expect(el(p)[1].class).toBe('my-5 leading-7 text-pretty text-accented')
+  })
+
+  it('leaves empty-theme tags (em, strong) without a class attribute', async () => {
+    const [p] = await parse('*em* and **strong**')
+    const em = el(el(p)[2] as Node)
+    const strong = el(el(p)[4] as Node)
+    expect(em[0]).toBe('em')
+    expect(em[1].class).toBeUndefined()
+    expect(strong[0]).toBe('strong')
+    expect(strong[1].class).toBeUndefined()
+  })
+
+  it('preserves author classes from the attributes syntax', async () => {
+    const [p] = await parse('**strong**{.text-red}')
+    const strong = el(el(p)[2] as Node)
+    expect(strong[1].class).toBe('text-red')
+  })
+
+  it('classes inline code with the neutral variant, dropping lang/color props', async () => {
+    const [p] = await parse('Some `code`{lang="ts"} here')
+    const code = el(el(p)[3] as Node)
+    expect(code[0]).toBe('code')
+    expect(code[1].class).toContain('font-mono')
+    expect(code[1].class).toContain('border-muted text-highlighted bg-muted')
+    expect(code[1].class).toContain('[font-variant-ligatures:none]')
+    expect(code[1].lang).toBeUndefined()
+    expect(code[1].color).toBeUndefined()
+  })
+
+  it('never touches <pre> subtrees (rangi owns them)', async () => {
+    const nodes = await parse('```ts\nconst a = 1\n```')
+    const pre = el(nodes[0])
+    expect(pre[0]).toBe('pre')
+    const code = el(pre[2] as Node)
+    expect(code[0]).toBe('code')
+    expect(code[1].class ?? '').not.toContain('px-1.5')
+  })
+
+  it('wraps tables in the ProseTable scroll container and classes cells', async () => {
+    const [wrapper] = await parse('| A | B |\n|:--|--:|\n| x | y |')
+    const div = el(wrapper)
+    expect(div[0]).toBe('div')
+    expect(div[1].class).toContain('overflow-x-auto')
+    const table = el(div[2] as Node)
+    expect(table[0]).toBe('table')
+    expect(table[1].class).toContain('border-separate')
+    const thead = el(table[2] as Node)
+    expect(thead[1].class).toBe('bg-muted')
+    const th = el(el(thead[2] as Node)[2] as Node)
+    expect(th[0]).toBe('th')
+    expect(th[1].class).toContain('text-start')
+    const tbody = el(table[3] as Node)
+    const td = el(el(tbody[2] as Node)[2] as Node)
+    expect(td[0]).toBe('td')
+    // default align variant + app.config override
+    expect(td[1].class).toContain('text-start')
+    expect(td[1].class).toContain('bg-white dark:bg-muted/80')
+  })
+
+  it('wraps h2 content in an anchor with the leading hash icon', async () => {
+    const [h2] = await parse('## Hello World')
+    const heading = el(h2)
+    expect(heading[0]).toBe('h2')
+    expect(heading[1].id).toBe('hello-world')
+    // app.config `font-medium` override wins over the theme's `font-bold`
+    expect(heading[1].class).toContain('font-medium')
+    // standalone `font-bold` is merged away; only the `[&>a>code]:` variant keeps it
+    expect(heading[1].class).not.toMatch(/(^| )font-bold( |$)/)
+    const link = el(heading[2] as Node)
+    // `prose-anchor` renders as a plain <a> via the proseElements map (a bare `a` tag would
+    // resolve to ProseA)
+    expect(link[0]).toBe('prose-anchor')
+    expect(link[1].href).toBe('#hello-world')
+    expect(link[1].class).toContain('group')
+    const leading = el(link[2] as Node)
+    expect(leading[0]).toBe('span')
+    expect(leading[1].class).toContain('group-hover:opacity-100')
+    const icon = el(leading[2] as Node)
+    expect(icon[1].class).toContain('prose-anchor-icon')
+    expect(icon[1].class).toContain('size-4')
+    expect(link[3]).toBe('Hello World')
+  })
+
+  it('classes h1 without an anchor (anchorLinks.h1 unset)', async () => {
+    const [h1] = await parse('# Title')
+    const heading = el(h1)
+    expect(heading[0]).toBe('h1')
+    expect(heading[1].class).toContain('text-4xl')
+    expect(heading[2]).toBe('Title')
+  })
+
+  it('respects an explicit anchor=false attribute', async () => {
+    const [h2] = await parse('## Quiet {anchor=false}')
+    const heading = el(h2)
+    expect(heading[1].anchor).toBeUndefined()
+    expect(heading[2]).toBe('Quiet')
+  })
+
+  it('classes lists and separators', async () => {
+    const nodes = await parse('- one\n- two\n\n---')
+    const ul = el(nodes[0])
+    expect(ul[1].class).toContain('list-disc')
+    const li = el(ul[2] as Node)
+    expect(li[1].class).toContain('ps-1.5')
+    const hr = el(nodes[1])
+    expect(hr[0]).toBe('hr')
+    expect(hr[1].class).toBe('border-t border-default my-12')
+  })
+})


### PR DESCRIPTION
## Summary

Long docs pages mount a Nuxt UI `Prose*` component instance for every paragraph, list item, table cell, and heading. This PR renders those static tags as plain HTML elements instead, with their Tailwind classes baked into the parsed tree, cutting per-node component instances from SSR, hydration, and client-side navigation.

## How it works

- **New `elements` comark plugin** (`server/utils/comark-elements.ts`): runs last in the parse pipeline and rewrites `p`, `em`, `strong`, `hr`, `ul`, `ol`, `li`, `blockquote`, inline `code`, the table family, and `h1`-`h4` into final HTML with classes merged from the Nuxt UI prose theme + `appConfig.ui.prose.*` overrides, using the same `tv({ extend: theme, ...override })` call the components make. It replicates component markup: table scroll-wrapper `div`, heading anchor links (per `mdc.headings.anchorLinks`) with the hash icon as a CSS mask, `code` color variants, cell alignment. `pre` subtrees are untouched (rangi owns them).
- **New `proseElements` map** (`app/utils/prose-elements.ts`): passed to `<MarkdownDocument :components>`, mapping each tag to its own name so the renderer emits `h('p')` instead of resolving the global `ProseP`. Heading anchors use a `prose-anchor` tag mapped to `'a'` so they do not resolve to `ProseA`.
- **`ProseImg` stays a component** (zoom dialog) but is now lazily hydrated with `hydrateOnVisible()`: its chunk (the largest prose chunk, 5.2 KB) only downloads once an image scrolls into view.
- Interactive prose stays as components: `a`, `pre`, callouts, tabs, code groups, etc. Children of native elements render normally, so in-content links keep SPA navigation.

## Wiring

- Plugin registered in `server/utils/content.ts`; `CONTENT_PARSER_VERSION` bumped to `v3` (cached trees change shape).
- Map spread into the docs page and landing page `MarkdownDocument` usages.
- `server/` added as a Tailwind source in `modules/css.ts` so the baked class literals stay covered even if they drift from the Nuxt UI theme.
- `tailwind-variants` added as a direct dependency (the plugin cannot use `@nuxt/ui/utils/tv`: it imports `#build/app.config`, which is forbidden in nitro).

## Impact

- Total client bundle: unchanged (+1.1 KB gzip, the anchor-icon CSS rule).
- Per docs page visit: 14+ prose chunk requests skipped (~7 KB gzip), `ProseImg` deferred until visible.
- Main win: zero component instances, `tv()` calls, and `useAppConfig` proxies for ~19 tags during SSR, hydration, and every client-side navigation.

## Trade-offs

- `appConfig.ui.prose.*` overrides are applied at parse time and frozen into the cached tree (still respected, verified in tests, but runtime `UTheme` context overrides no longer affect these tags).
- Theme class literals mirror Nuxt UI 4.11 and need a sync check when upgrading `@nuxt/ui` (noted in the plugin docblock).

## Verification

- 10 new unit tests (`test/comark-elements.test.ts`): class baking, app.config merging, author-class preservation, `pre` skip, table wrapper, heading anchors, alignment. Full suite: 164 passed.
- `nuxt typecheck` clean, eslint clean (only pre-existing warnings).
- SSR HTML diffed against the previous output on the playground: paragraph/list/table/code classes, heading anchor markup, `ProseA` link styling, and image zoom attributes are identical.

---

🤖 Opened by an AI coding agent (OpenCode) on behalf of @atinux, who reviewed the changes.