### PR TITLE
feat(content): pin instances per commit with withRef()

### DIFF
--- a/modules/snapshot/index.ts
+++ b/modules/snapshot/index.ts
@@ -12,8 +12,9 @@ const logger = useLogger('comark-docs')
 const ASSET_BASE = 'comark-content'
 
 /**
- * Writes a build-time content snapshot into the function bundle.
- * A cold start then hydrates from it instead of walking the content repository.
+ * Writes a build-time content snapshot into the function bundle, stamped with the commit it was
+ * parsed at. A cold start at that commit hydrates from it instead of walking the content
+ * repository; a cold start at a later commit reuses every unchanged body from it.
  */
 export default defineNuxtModule({
   meta: { name: 'comark-docs:snapshot' },
@@ -52,16 +53,19 @@ export default defineNuxtModule({
         return
       }
 
-      const content = createBuildContentInstance({ source: fs(contentPath) })
+      // Pinned to the content commit, so the artifact carries `ref`. At runtime an instance pinned
+      // to the same commit uses it as its index; one pinned to a later commit walks that commit
+      // for the index and still takes every body whose source text did not change.
+      const content = createBuildContentInstance({ source: fs(contentPath) }).withRef(sha)
 
       try {
         const writeStart = performance.now()
-        await writeSnapshots(content, { dir: join(dir, sha), manifest: false })
+        await writeSnapshots(content, { dir, manifest: false })
         const writeMs = Math.round(performance.now() - writeStart)
 
         // Size is the number to watch: the snapshot is inlined into the bundle as a string.
         // Every cold start that reads it pays for that.
-        const { size } = await stat(join(dir, sha, DEFAULT_CONTENT_NAME, 'snapshot.json'))
+        const { size } = await stat(join(dir, DEFAULT_CONTENT_NAME, 'snapshot.json'))
         logger.success(
           `Content snapshot ${sha.slice(0, 7)}: ${Math.round(size / 1024)} kB parsed and written in ${writeMs}ms ` +
             `(ref resolved in ${resolveMs}ms)`

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ai": "^7.0.77",
     "beautiful-mermaid": "^1.1.3",
     "comark": "^0.6.2",
-    "comark-content": "https://pkg.pr.new/comark-content@63ffc3f",
+    "comark-content": "https://pkg.pr.new/comark-content@98457f7",
     "defu": "^6.1.7",
     "exsolve": "^1.1.1",
     "js-yaml": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2(beautiful-mermaid@1.1.3)(rangi@2.2.0)(shiki@4.4.3)
       comark-content:
-        specifier: https://pkg.pr.new/comark-content@63ffc3f
-        version: https://pkg.pr.new/comark-content@63ffc3f(@vercel/functions@3.9.5(ws@8.21.3))(beautiful-mermaid@1.1.3)(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(rangi@2.2.0)(shiki@4.4.3)
+        specifier: https://pkg.pr.new/comark-content@98457f7
+        version: https://pkg.pr.new/comark-content@98457f7(@vercel/functions@3.9.5(ws@8.21.3))(beautiful-mermaid@1.1.3)(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(rangi@2.2.0)(shiki@4.4.3)
       defu:
         specifier: ^6.1.7
         version: 6.1.7
@@ -3349,8 +3349,8 @@ packages:
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
 
-  comark-content@https://pkg.pr.new/comark-content@63ffc3f:
-    resolution: {integrity: sha512-F0jDyRaJqfASydFGik1UpAlfqa9SmrDV+Sj2QfjoO6vJHtH8xZiAf0XSmOFfPcGI5QMRKnrqqyZy1ei5RJ6IWQ==, tarball: https://pkg.pr.new/comark-content@63ffc3f}
+  comark-content@https://pkg.pr.new/comark-content@98457f7:
+    resolution: {integrity: sha512-dZDkLzclMwdKu7p28PetFlVW8Xj24dHElWPEWfYTL/mWv6u4MkY5ECHwVdHI+4H4wM78+/7uPB4Xq4dtoznmMw==, tarball: https://pkg.pr.new/comark-content@98457f7}
     version: 0.3.0
     hasBin: true
 
@@ -10138,7 +10138,7 @@ snapshots:
 
   colortranslator@5.0.0: {}
 
-  comark-content@https://pkg.pr.new/comark-content@63ffc3f(@vercel/functions@3.9.5(ws@8.21.3))(beautiful-mermaid@1.1.3)(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(rangi@2.2.0)(shiki@4.4.3):
+  comark-content@https://pkg.pr.new/comark-content@98457f7(@vercel/functions@3.9.5(ws@8.21.3))(beautiful-mermaid@1.1.3)(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(rangi@2.2.0)(shiki@4.4.3):
     dependencies:
       citty: 0.2.2
       comark: 0.6.2(beautiful-mermaid@1.1.3)(rangi@2.2.0)(shiki@4.4.3)

--- a/server/api/content/blob/[sha]/[...path].get.ts
+++ b/server/api/content/blob/[sha]/[...path].get.ts
@@ -20,20 +20,6 @@ export default defineEventHandler(async (event) => {
   // Also resolves short SHAs so one commit pins one content instance.
   const fullSha = await authorizePreviewSha(sha)
 
-  // Head-of-branch requests reuse the shared prod instance (same source ref, same per-SHA cache
-  // namespace) instead of minting a duplicate preview instance that would pin an LRU slot with a
-  // clone of production. Re-checked after `getProdContent()`, which may advance the head.
-  if (fullSha === getHeadRef()) {
-    const prod = await getProdContent()
-    if (fullSha === getHeadRef()) {
-      const request = toWebRequest(event)
-      const url = new URL(request.url)
-      url.pathname = url.pathname.replace(`/blob/${rawSha}`, '')
-      return await prod.handler(new Request(url, request))
-    }
-  }
-
-  const content = await getPreviewContent(fullSha, `/api/content/blob/${sha}`)
-
-  return await content.handler(toWebRequest(event))
+  // Head-of-branch requests reuse the shared prod instance; `servePreview()` handles that.
+  return servePreview(event, fullSha, `/blob/${rawSha}`)
 })

--- a/server/api/content/pr/[number]/[...path].get.ts
+++ b/server/api/content/pr/[number]/[...path].get.ts
@@ -17,7 +17,5 @@ export default defineEventHandler(async (event) => {
   }
 
   const sha = await resolvePullPreviewSha(number)
-  const content = await getPreviewContent(sha, `/api/content/pr/${number}`)
-
-  return await content.handler(toWebRequest(event))
+  return servePreview(event, sha, `/pr/${rawNumber}`)
 })

--- a/server/api/content/tree/[branch]/[...path].get.ts
+++ b/server/api/content/tree/[branch]/[...path].get.ts
@@ -14,7 +14,5 @@ export default defineEventHandler(async (event) => {
 
   // `cacheMisses`: the ref comes from the URL, so a miss must not re-cost a GitHub call each time.
   const sha = await resolveContentSha(branch, useRuntimeConfig(event).docs.contentDir, { cacheMisses: true })
-  const content = await getPreviewContent(sha, `/api/content/tree/${encodeURIComponent(branch)}`)
-
-  return await content.handler(toWebRequest(event))
+  return servePreview(event, sha, `/tree/${rawBranch}`)
 })

--- a/server/api/revalidate.post.ts
+++ b/server/api/revalidate.post.ts
@@ -89,10 +89,12 @@ export default defineEventHandler(async (event) => {
 
     // Refresh the content SHA
     const headSha = await resolveContentSha(branch, contentDir, { refresh: true })
-    const freshContent = await createSourceContent(headSha, { cache: { driver: cacheDriver(headSha) } })
-    // Partial init: the diff needs the index (cache will be reused by the warm below)
-    await freshContent.init()
-    const newItems = (await freshContent.manifest()).items
+    // A throwaway instance pinned to the new commit: the diff needs its index only. Its index lands
+    // in the commit's cache namespace, which the prod swap and the warm below then reuse.
+    const fresh = contentAt(headSha)
+    await fresh.init()
+    const newItems = (await fresh.manifest()).items
+    await fresh.dispose()
 
     return { headSha, newItems, ...diffContent(changes, oldItems, newItems) }
   })

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -20,34 +20,27 @@ function cacheAvailable(): boolean {
 export const CONTENT_PARSER_VERSION = 'v3'
 
 /**
- * The driver behind comark's index, parsed bodies and artifacts, for every commit. One namespace
- * per parser version; `content.withRef(sha)` adds a per-commit namespace on top, so instances
- * pinned to different commits share this driver without reading each other's entries. Bumping
- * the parser version leaves every commit's entries behind at once.
+ * The driver behind everything cached per parser version, under `content:<version>`:
+ *
+ * - without `sha`, comark's index, parsed bodies and artifacts for every commit. An instance pinned
+ *   with `content.withRef(sha)` adds its own `ref:<sha>:` prefix, so instances pinned to different
+ *   commits share this driver without reading each other's entries;
+ * - with `sha`, ad-hoc per-commit data (commit history, RSS dates) under `content:<version>:<sha>`.
+ *   Those keys start with `gh:` and never meet comark's.
+ *
+ * Bumping the parser version leaves every commit's entries behind at once.
  */
-export function contentCacheDriver(): Driver {
+export function contentCacheDriver(sha?: string): Driver {
   if (!cacheAvailable()) return memoryDriver()
   return vercelRuntimeCache({
-    base: `content:${CONTENT_PARSER_VERSION}`,
+    base: sha ? `content:${CONTENT_PARSER_VERSION}:${sha}` : `content:${CONTENT_PARSER_VERSION}`,
     ttl: TTL,
   })
 }
 
-/** Per-SHA driver for non-content data. */
-function shaCacheDriver(sha: string): Driver {
-  if (!cacheAvailable()) return memoryDriver()
-  return vercelRuntimeCache({
-    base: `content:${CONTENT_PARSER_VERSION}:${sha}`,
-    ttl: TTL,
-  })
-}
-
-/**
- * Ad-hoc per-SHA storage for non-content data (commit history, RSS dates). Its own namespace: comark's
- * entries live under `contentCacheDriver()` with a `ref:` prefix, so `gh:...` keys never meet them.
- */
+/** Ad-hoc per-SHA storage for non-content data (commit history, RSS dates). */
 export function shaCacheStorage(sha: string): Storage {
-  return createStorage({ driver: shaCacheDriver(sha) })
+  return createStorage({ driver: contentCacheDriver(sha) })
 }
 
 /**

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -19,8 +19,22 @@ function cacheAvailable(): boolean {
  */
 export const CONTENT_PARSER_VERSION = 'v3'
 
-/** Per-parser-version, per-content-SHA driver backing comark's manifest and parsed bodies. */
-export function cacheDriver(sha: string): Driver {
+/**
+ * The driver behind comark's index, parsed bodies and artifacts, for every commit. One namespace
+ * per parser version; `content.withRef(sha)` adds a per-commit namespace on top, so instances
+ * pinned to different commits share this driver without reading each other's entries. Bumping
+ * the parser version leaves every commit's entries behind at once.
+ */
+export function contentCacheDriver(): Driver {
+  if (!cacheAvailable()) return memoryDriver()
+  return vercelRuntimeCache({
+    base: `content:${CONTENT_PARSER_VERSION}`,
+    ttl: TTL,
+  })
+}
+
+/** Per-SHA driver for non-content data. */
+function shaCacheDriver(sha: string): Driver {
   if (!cacheAvailable()) return memoryDriver()
   return vercelRuntimeCache({
     base: `content:${CONTENT_PARSER_VERSION}:${sha}`,
@@ -29,12 +43,11 @@ export function cacheDriver(sha: string): Driver {
 }
 
 /**
- * Ad-hoc per-SHA storage for non-content data (commit history, RSS dates). Shares comark's
- * `cacheDriver(sha)` namespace rather than a separate unconfigured mount; `gh:...` keys can't
- * collide with comark's `<source>:<path>`.
+ * Ad-hoc per-SHA storage for non-content data (commit history, RSS dates). Its own namespace: comark's
+ * entries live under `contentCacheDriver()` with a `ref:` prefix, so `gh:...` keys never meet them.
  */
 export function shaCacheStorage(sha: string): Storage {
-  return createStorage({ driver: cacheDriver(sha) })
+  return createStorage({ driver: shaCacheDriver(sha) })
 }
 
 /**

--- a/server/utils/content.ts
+++ b/server/utils/content.ts
@@ -1,58 +1,49 @@
-import { type CacheOptions, type ContentSource, DEFAULT_CONTENT_NAME } from 'comark-content'
+import { type ContentSource, DEFAULT_CONTENT_NAME } from 'comark-content'
 import fs from 'comark-content/sources/fs'
 import github from 'comark-content/sources/github'
 import { withSnapshot } from 'comark-content/sources/snapshot'
 import { createRuntimeContentInstance } from '../../utils/content.ts'
 
 /**
- * The instance this layer builds, derived from the factory rather than written
- * out.
+ * The instance this layer serves from, derived from the factory rather than written out.
  *
- * `ComarkContent` is the *unnarrowed* shape: its instance-name parameter drives
- * the conditional types behind `get()` and `list()`, so a concrete instance is
- * not assignable to it. Deriving instead of annotating keeps the narrowing that
- * `comark-content prepare` generates — `get('/known/path')` stays typed all the
- * way through the layer.
+ * `ComarkContent` is the *unnarrowed* shape: its instance-name parameter drives the conditional
+ * types behind `get()` and `list()`, so a concrete instance is not assignable to it. Deriving
+ * instead of annotating keeps the narrowing that `comark-content prepare` generates —
+ * `get('/known/path')` stays typed all the way through the layer.
  */
-export type DocsContent = Awaited<ReturnType<typeof createSourceContent>>
-
-// Rebuilt only when the head advances (see `getProdContent`). Holds the *promise*, not the instance: the
-// assignment lands after the await, so two requests on a cold instance would each build a CMS.
-let content: Promise<DocsContent> | undefined
+export type DocsContent = ReturnType<typeof createBaseContent>
 
 /**
- * Create a new content instance reading content at `ref` (a commit SHA or branch).
- * - `remote` forces the GitHub source
- * - `cache` overrides comark's (in-memory by default)
- * - `basePath` is the base path for the content instance
- * - `watch` is dev file watching
+ * One instance per process holds the source, the plugins and the cache driver. Every instance that
+ * serves requests is `base.withRef(sha)`: the same options, pinned to a commit, with its own index
+ * and its own cache namespace (`ref:<sha>:` under `contentCacheDriver()`). Nothing is ever read
+ * from the base itself in production; in development it is the unpinned, watched instance.
  */
-export async function createSourceContent(
-  ref: string,
-  opts: { remote?: boolean; cache?: CacheOptions; basePath?: string; watch?: boolean } = {}
-) {
-  const instance = createRuntimeContentInstance({
-    source: contentSource(ref, { remote: opts.remote }),
-    cache: opts.cache,
-    basePath: opts.basePath,
-  })
+let base: DocsContent | undefined
 
-  // Only the default instance watches: others read a fixed ref that can't change, and retaining
-  // `watch()`'s stop function to release the watcher would leak once the preview entry is evicted.
-  if (import.meta.dev && opts.watch) {
-    await instance.watch()
-    instance.hooks.hook('watch:file:update', (_source:string, key: string) => {
-      invalidateSearchSections(instance)
-      console.log(`${key} updated`)
-    })
-    instance.hooks.hook('watch:file:remove', () => invalidateSearchSections(instance))
-  }
-
-  return instance
+function getBaseContent(): DocsContent {
+  base ??= createBaseContent()
+  return base
 }
 
-// The content commit this instance is pinned to. Pinning GitHub reads to an immutable SHA rather
-// than the branch name bypasses the stale `raw.githubusercontent.com/<branch>` CDN.
+function createBaseContent() {
+  return createRuntimeContentInstance({
+    source: contentSource(),
+    cache: { driver: contentCacheDriver() },
+  })
+}
+
+/**
+ * An instance pinned to `sha`. Cheap to create: no read happens until the first call. Keep it for
+ * as long as you serve that commit, and `dispose()` it when you replace it.
+ */
+export function contentAt(sha: string): DocsContent {
+  return getBaseContent().withRef(sha)
+}
+
+// The content commit this process serves. Pinning GitHub reads to an immutable SHA rather than the
+// branch name bypasses the stale `raw.githubusercontent.com/<branch>` CDN.
 let headRef: string | undefined
 
 export function getHeadRef(): string {
@@ -74,10 +65,14 @@ export async function resolveProdSha(): Promise<string> {
   return resolveContentSha(targetBranch(), contentDir)
 }
 
+// Rebuilt only when the head advances (see `getProdContent`). Holds the *promise*, not the instance:
+// the assignment lands after the await, so two requests on a cold process would each build one.
+let prod: Promise<DocsContent> | undefined
+
 /**
- * Shared content instance for the lifetime of this server instance, pinned to `headRef`. In production every
- * call resolves the current head via `resolveProdSha()` — a shared, short-TTL cache, not a per-instance
- * timer — and rebuilds when that advances. Previews stay pinned.
+ * Shared content instance for the lifetime of this process, pinned to `headRef`. In production every
+ * call resolves the current head via `resolveProdSha()` — a shared, short-TTL cache, not a per-process
+ * timer — and swaps to a new pinned instance when it advances. Previews stay pinned.
  */
 export async function getProdContent(): Promise<DocsContent> {
   if (['production', 'preview'].includes(process.env.VERCEL_ENV || '')) {
@@ -85,65 +80,85 @@ export async function getProdContent(): Promise<DocsContent> {
     if (sha !== getHeadRef()) {
       console.log(`[content] head ${getHeadRef()} -> ${sha}`)
       headRef = sha
-      content = undefined // the old instance baked its source at the old commit
+      // The old instance is pinned to the old commit; release it. Its cache entries stay for
+      // anything still reading `/blob/<old sha>`.
+      void prod?.then((instance) => instance.dispose()).catch(() => {})
+      prod = undefined
     }
   }
 
-  if (!content) {
-    content = createSourceContent(getHeadRef(), {
-      watch: true,
-      cache: {
-        driver: cacheDriver(getHeadRef()),
-      },
+  if (!prod) {
+    prod = (async () => {
+      // Development reads the working tree and watches it; production and previews read a commit.
+      const instance = import.meta.dev ? await watchedDevContent() : contentAt(getHeadRef())
+      const startedAt = performance.now()
+      await instance.init()
+      recordDuration('content.init.ms', startedAt)
+      return instance
+    })().catch((error) => {
+      // Don't memoize a failed build — the next request should retry.
+      prod = undefined
+      throw error
     })
-      .then(async (instance) => {
-        const startedAt = performance.now()
-        await instance.init()
-        recordDuration('content.init.ms', startedAt)
-        return instance
-      })
-      .catch((error) => {
-        // Don't memoize a failed build — the next request should retry.
-        content = undefined
-        throw error
-      })
   }
-  return content
+  return prod
 }
 
-function contentSource(ref: string, opts: { remote?: boolean } = {}): ContentSource {
+/** The unpinned base in development: it reads the working tree and follows file changes. */
+async function watchedDevContent(): Promise<DocsContent> {
+  const instance = getBaseContent()
+  await instance.watch()
+  instance.hooks.hook('watch:file:update', (_source: string, key: string) => {
+    invalidateSearchSections(instance)
+    console.log(`${key} updated`)
+  })
+  instance.hooks.hook('watch:file:remove', () => invalidateSearchSections(instance))
+  return instance
+}
+
+/**
+ * The source every instance derives from. `withRef(sha)` pins it to a commit:
+ * - in production the GitHub source reads its tree and files at `sha`, and the build-time snapshot
+ *   supplies every body whose source text did not change since the build;
+ * - in development the working tree is read unpinned, and a pinned instance reads the local git
+ *   history at `sha` instead (previews).
+ */
+function contentSource(): ContentSource {
   const { docs } = useRuntimeConfig()
 
   if (import.meta.dev) {
-    if (opts.remote) return gitLocalSource(ref, docs.contentDir)
-
-    return fs(docs.contentPath)
+    return {
+      ...fs(docs.contentPath),
+      withRef: (ref) => gitLocalSource(ref, docs.contentDir),
+    }
   }
 
   const source = github({
     repo: githubRepo(),
-    branch: ref,
+    branch: targetBranch(),
     path: docs.contentDir,
     token: githubToken(),
-    // `ref` is an immutable commit SHA => we can cache hard.
+    // Reads happen through `withRef(<sha>)`, an immutable commit => cache hard.
     ttl: 60 * 60 * 24,
   })
 
-  // The snapshot shipped during build by `modules/snapshot/`.
-  return withSnapshot(source, () => readSnapshot(ref))
+  // The snapshot shipped during build by `modules/snapshot/`. It carries the commit it was parsed
+  // at, so it is returned for every ref: at that commit it is the index, at any other commit
+  // comark-content walks the commit for the index and reuses the unchanged bodies by hash.
+  return withSnapshot(source, () => readSnapshot())
 }
 
 /**
- * Read the build-time snapshot stored under `ref`, or nothing when this deployment did not ship one.
+ * Read the build-time snapshot, or nothing when this deployment did not ship one.
  *
  * Timed because the duration is the point: the lazy import of the bundled chunk plus its JSON parse.
  */
-async function readSnapshot(ref: string): Promise<unknown> {
-  const span = contentTracer()?.startSpan('snapshot:read', { attributes: { 'comark.ref': ref } })
+async function readSnapshot(): Promise<unknown> {
+  const span = contentTracer()?.startSpan('snapshot:read')
   const startedAt = performance.now()
   try {
     // Untyped read: unstorage runs every value through `destr`, so this arrives already parsed.
-    const data = await useStorage('assets:comark-content').get(`${ref}/${DEFAULT_CONTENT_NAME}/snapshot.json`)
+    const data = await useStorage('assets:comark-content').get(`${DEFAULT_CONTENT_NAME}/snapshot.json`)
     const hit = data != null
     span?.setAttribute('comark.snapshot.hit', hit)
     recordDuration('content.snapshot.read.ms', startedAt, { hit: String(hit) })
@@ -153,39 +168,54 @@ async function readSnapshot(ref: string): Promise<unknown> {
   }
 }
 
-/** Per-instance registry of preview CMS instances, keyed by `<basePath>::<sha>`. */
-const contentPreviewInstances = new Map<string, Promise<DocsContent>>()
+/** Per-process registry of preview instances, keyed by commit. */
+const previews = new Map<string, DocsContent>()
 
-// Bound required: each entry is a content instance with its own manifest and parsed bodies, and public
-// `/tree/:branch` / `/blob/:sha` let a crawler mint one per SHA. Evicted refs just rebuild, their
-// bodies surviving in the per-SHA Runtime Cache.
+// Bound required: each entry holds an index in memory, and public `/tree/:branch` / `/blob/:sha`
+// let a crawler mint one per SHA. An evicted entry is disposed; its bodies survive in the shared
+// cache under its `ref:` namespace, so rebuilding it later is a cache read, not a walk.
 const MAX_PREVIEW_INSTANCES = 8
 
-export function getPreviewContent(sha: string, basePath: string): Promise<DocsContent> {
-  const key = `${basePath}::${sha}`
-  const existing = contentPreviewInstances.get(key)
+export function getPreviewContent(sha: string): DocsContent {
+  const existing = previews.get(sha)
   if (existing) {
     // `Map` preserves insertion order, which is the whole LRU: re-insert so the MRU key is last.
-    contentPreviewInstances.delete(key)
-    contentPreviewInstances.set(key, existing)
+    previews.delete(sha)
+    previews.set(sha, existing)
     return existing
   }
 
-  const instance = createSourceContent(sha, {
-    remote: true,
-    basePath,
-    cache: { driver: cacheDriver(sha) },
-  }).catch((error) => {
-    contentPreviewInstances.delete(key)
-    throw error
-  })
-  contentPreviewInstances.set(key, instance)
+  const instance = contentAt(sha)
+  previews.set(sha, instance)
 
-  while (contentPreviewInstances.size > MAX_PREVIEW_INSTANCES) {
-    const oldest = contentPreviewInstances.keys().next()
+  while (previews.size > MAX_PREVIEW_INSTANCES) {
+    const oldest = previews.keys().next()
     if (oldest.done) break
-    contentPreviewInstances.delete(oldest.value)
+    const evicted = previews.get(oldest.value)
+    previews.delete(oldest.value)
+    void evicted?.dispose().catch(() => {})
   }
 
   return instance
+}
+
+/**
+ * Serve a preview request through the instance pinned to `sha`. Preview routes are mounted under
+ * `/api/content/<kind>/<ref>`; every instance's handler expects the shared base path, so the
+ * `/<kind>/<ref>` segment is stripped before dispatch (`/api/content/blob/abc/get/x` becomes
+ * `/api/content/get/x`). Pass the segment as it appears in the URL, un-decoded. Head-of-branch
+ * requests reuse the shared prod instance instead of a duplicate preview pinned to the same commit.
+ */
+export async function servePreview(event: Parameters<typeof toWebRequest>[0], sha: string, segment: string) {
+  const request = toWebRequest(event)
+  const url = new URL(request.url)
+  url.pathname = url.pathname.replace(segment, '')
+  const rewritten = new Request(url, request)
+
+  if (sha === getHeadRef()) {
+    const instance = await getProdContent()
+    // `getProdContent()` may have advanced the head; re-check before reusing it.
+    if (sha === getHeadRef()) return instance.handler(rewritten)
+  }
+  return getPreviewContent(sha).handler(rewritten)
 }

--- a/server/utils/webhook.ts
+++ b/server/utils/webhook.ts
@@ -15,7 +15,7 @@ export interface ContentChanges {
 /** Files the content source can actually serve — matches the parsers installed in `content.ts`. */
 const CONTENT_EXTENSIONS = ['.md', '.yml', '.yaml', '.json']
 
-/** The content instance's name (see `createSourceContent()` in `content.ts`) — unnamed, so `default`. */
+/** The content instance's name (see `createBaseContent()` in `content.ts`) — unnamed, so `default`. */
 const SOURCE_NAME = DEFAULT_CONTENT_NAME
 
 /**


### PR DESCRIPTION
> Written by an AI agent on behalf of @atinux, who is reviewing it.

Stacked on #22. Depends on `comark-content@98457f7` from comarkdown/comark-content#120 (already bumped here via pkg.pr.new). Merge #22 first; GitHub will retarget this to `main`.

## What

The layer already ran "one instance per content commit, swap when the branch moves". This PR moves the mechanics into `comark-content`, which now provides them:

- **One base instance per process.** Every serving instance is `base.withRef(sha)`: same source, plugins and cache driver, pinned to a commit, with its own index and its own cache namespace (`ref:<sha>:` under `content:<parserVersion>`). `cacheDriver(sha)` is gone for content; `shaCacheStorage()` keeps a per-SHA driver for its `gh:` keys.
- **The build snapshot carries its commit.** `modules/snapshot` parses on an instance pinned to the resolved content commit, so the artifact is stamped with `ref`. At that commit it is the index and a cold start makes no GitHub call. At a later commit `comark-content` walks the commit for the index (frontmatter only) and reuses every body whose `meta.hash` is unchanged, so a push costs one walk plus a parse of the changed files instead of a full parse. The artifact lives at a fixed path now (`comark-content/default/snapshot.json`), no per-SHA directory.
- **Previews share the default base path.** `/blob/:sha`, `/tree/:branch` and `/pr/:number` strip their mount segment and dispatch through `servePreview()`, which also keeps the head-of-branch shortcut to the prod instance. `getPreviewContent(sha)` loses its `basePath` argument.
- **`dispose()`** on the instance the prod swap drops, on preview LRU eviction (which fixes the watcher-leak caveat noted in the old `createSourceContent`), and on the webhook's throwaway diff instance.
- In development, the base source is `fs()` with a `withRef` that reads local git history, so `withRef(sha)` previews keep working without a second code path.

`createSourceContent()` is replaced by `contentAt(sha)`.

## Verified

- `vitest run`: 19 files, 177 tests pass. `eslint .` and `nuxt typecheck playground` pass.
- `nuxt build playground`: the module logs `Content snapshot f97dc86: 200 kB`; the emitted artifact has `ref: f97dc86…` and a `meta.hash` on all 20 items.
- Built server, `VERCEL_GIT_COMMIT_REF` set to that commit, **network blocked**: `/api/content/get/...` and `/navigation` return 200. Zero GitHub calls.
- Same server pinned to `main` (a later commit): 200 with the network; with it blocked it fails on the tree walk, as expected, since the index must come from the commit.

## Not in this PR

- `read:after` cache tags: the layer purges by URL from the webhook diff, so nothing to wire yet.
- `clean()` for deleted preview branches: nothing enumerates stale refs today; the Runtime Cache TTL (24 h) covers it.
